### PR TITLE
added a a 15mins timeout for all jobs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@master


### PR DESCRIPTION
I was tasked to add a timeout for all GitHub actions to avoid runaway jobs.

added a timeout block to the action's file